### PR TITLE
Improve stack detection logic / add more options to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,14 @@ There is a simple GUI for the `--lightroomimport` workflow. It asks for the sour
    either one.
 4. **Optionally check _Dry run_** to preview every move without doing anything —
    the button changes to **Preview (dry run)**. Check **Verbose log** for
-   per-file detail.
-5. **Click _Start import_.** A progress bar and live log show each file as it
-   moves, with a running `done / total` count. You can **Cancel** at any time —
-   files move one at a time and the import is re-runnable, so stopping is safe.
-   If the destination is low on space, it asks before continuing.
+   per-file detail, **Show stack debug output** for stack-detection diagnostics,
+   or **Leave files on card** to copy into the destination folders without
+   deleting the source files.
+5. **Click _Start import_.** A progress bar and live log show each file as it is
+   moved or copied, with a running `done / total` count. You can **Cancel** at
+   any time — files are processed one at a time and the import is re-runnable,
+   so stopping is safe. If the destination is low on space, it asks before
+   continuing.
 6. When it finishes, **Open destination** opens your Lightroom folder.
 
 Files land in exactly the same place as the `--lightroomimport` command — see
@@ -259,9 +262,10 @@ Date filters work with all modes.
 - `--dry` / `--dry-run` — Preview what would happen without making changes
 - `-v` / `--verbose` — Show detailed info about each file processed
 - `-i` / `--interactive` — Ask for confirmation before moving (`--lightroomimport` only)
+- `--leave-on-card` — Copy during `--lightroomimport` instead of moving, leaving source files in place
 - `--force` — Overwrite existing files without asking
 - `-j N` / `--jobs N` — Use N parallel workers for `--copy`, `--stackcopy`, and `--lightroom`. `--lightroomimport` always runs sequentially to preserve oldest-first order.
-- `--debug-stacks` — Show detailed diagnostics for stack detection
+- `--debug-stacks` / `--debugstacks` — Show detailed diagnostics for stack detection
 
 ## Stack detection in Lightroom modes
 

--- a/stackcopy.py
+++ b/stackcopy.py
@@ -1336,6 +1336,76 @@ def main():
         sequence = sorted(stems_by_num.items())
         return sequence, sequence_dirs_with_matches
 
+    def stack_detection_group_key(record):
+        """Group files for stack detection by folder and numeric filename prefix."""
+        numeric_info = record.get("numeric")
+        prefix = numeric_info["prefix"] if numeric_info else None
+        return (record.get("relative_dir", "."), prefix)
+
+    # Reliable stack detection needs RAW+JPG pairing; in groups (folder +
+    # numeric filename prefix) that have JPGs but no RAW at all, disable it.
+    # Only the Lightroom modes consume this, so skip the scan otherwise.
+    jpg_only_stack_groups = set()
+    if operation_mode in ("lightroomimport", "lightroom"):
+        groups_with_jpg = set()
+        groups_with_raw = set()
+        for record in file_db.values():
+            has_jpg = record.get("has_jpg")
+            has_raw = record.get("has_raw")
+            if not (has_jpg or has_raw):
+                continue
+            group = stack_detection_group_key(record)
+            if has_jpg:
+                groups_with_jpg.add(group)
+            if has_raw:
+                groups_with_raw.add(group)
+        jpg_only_stack_groups = groups_with_jpg - groups_with_raw
+    warned_jpg_only_stack_groups = set()
+
+    def describe_stack_detection_group(group):
+        relative_dir, prefix = group
+        folder = src_dir if relative_dir == "." else os.path.join(src_dir, relative_dir)
+        if prefix is None:
+            return display_path(folder)
+        return f"{display_path(folder)} (filename prefix '{prefix}')"
+
+    def warn_jpg_only_stack_group(group):
+        if group in warned_jpg_only_stack_groups:
+            return
+        warned_jpg_only_stack_groups.add(group)
+        print(
+            f"Warning: JPG-only import detected in {describe_stack_detection_group(group)}: "
+            "no RAW files were found, so Stackcopy cannot reliably distinguish "
+            "in-camera stack outputs from normal JPGs or focus-bracketing bursts. "
+            "Stack detection has been disabled for this folder. All JPGs will be "
+            "imported normally. For automatic stack sorting, enable RAW+JPG in "
+            "the camera."
+        )
+
+    def find_stack_output_candidates():
+        """Return JPG-without-RAW stems, excluding JPG-only detection groups."""
+        stacked_outputs = set()
+        for stem, data in file_db.items():
+            if not (data.get("has_jpg") and not data.get("has_raw")):
+                continue
+
+            jpg_record = data["files"].get("jpg")
+            if not jpg_record:
+                continue
+
+            if target_date:
+                file_date = get_file_date(jpg_record, args.verbose)
+                if file_date is None or file_date != target_date:
+                    continue
+
+            group = stack_detection_group_key(data)
+            if group in jpg_only_stack_groups:
+                warn_jpg_only_stack_group(group)
+                continue
+
+            stacked_outputs.add(stem)
+        return stacked_outputs
+
     # --- 2. Process files based on operation mode ---
 
     if operation_mode == "lightroomimport":
@@ -1357,17 +1427,7 @@ def main():
         # --- Phase A: Detection and Planning ---
 
         # A1. Find stacked output candidates (JPG without RAW)
-        stacked_outputs = set()
-        for stem, data in file_db.items():
-            if data.get("has_jpg") and not data.get("has_raw"):
-                jpg_record = data["files"].get("jpg")
-                if not jpg_record:
-                    continue
-                if target_date:
-                    file_date = get_file_date(jpg_record, args.verbose)
-                    if file_date is None or file_date != target_date:
-                        continue
-                stacked_outputs.add(stem)
+        stacked_outputs = find_stack_output_candidates()
 
         # A2. Stack detection (same reverse-sorted walk as before)
         claimed_input_stems = set()
@@ -1839,6 +1899,11 @@ def main():
         file_operation = "copy" if args.leave_on_card else "move"
         operation_label = "copying" if args.leave_on_card else "moving"
         planned_action_noun = "copies" if args.leave_on_card else "moves"
+        past_tense_verb = "Copied" if args.leave_on_card else "Moved"
+        # "Would copy"/"Will copy" for the plan summary, "Would copy"/"Copied"
+        # for per-file execution lines (and likewise for moves).
+        planned_verb = f"Would {file_operation}" if args.dry_run else f"Will {file_operation}"
+        done_verb = f"Would {file_operation}" if args.dry_run else past_tense_verb
 
         # --- Phase B: Disk space preflight (unified) ---
         if planned_moves:
@@ -1865,10 +1930,7 @@ def main():
         total_rejected = stack_outputs_seen - accepted_stacks
         all_dest_dirs = sorted(set(display_path(m.dest_dir) for m in planned_moves))
 
-        if args.leave_on_card:
-            verb = "Would copy" if args.dry_run else "Will copy"
-        else:
-            verb = "Would move" if args.dry_run else "Will move"
+        verb = planned_verb
         dry_prefix = "DRY RUN: " if args.dry_run else ""
 
         print(f"\n{dry_prefix}Planned Lightroom import for '{src_dir}':")
@@ -1995,10 +2057,7 @@ def main():
                     remaining_moved_count += 1
 
                 if args.verbose or args.dry_run:
-                    if args.leave_on_card:
-                        verb = "Would copy" if args.dry_run else "Copied"
-                    else:
-                        verb = "Would move" if args.dry_run else "Moved"
+                    verb = done_verb
                     dest_short = display_path(move.dest_dir)
                     if move.basename_dest != move.basename_orig:
                         print(
@@ -2100,10 +2159,7 @@ def main():
                             total_bytes_moved += bytes_moved
                             remaining_moved_count += 1
                             if args.verbose or args.dry_run:
-                                if args.leave_on_card:
-                                    verb = "Would copy" if args.dry_run else "Copied"
-                                else:
-                                    verb = "Would move" if args.dry_run else "Moved"
+                                verb = done_verb
                                 dest_short = display_path(dest_dir_import)
                                 print(
                                     f"{verb} remaining '{file_info['basename']}' as '{file_dest_basename}' -> '{dest_short}'"
@@ -2124,17 +2180,7 @@ def main():
         # ================================================================
         input_dest_dirs = set()
         collision_notified = set()
-        stacked_outputs = set()
-        for stem, data in file_db.items():
-            if data.get("has_jpg") and not data.get("has_raw"):
-                jpg_record = data["files"].get("jpg")
-                if not jpg_record:
-                    continue
-                if target_date:
-                    file_date = get_file_date(jpg_record, args.verbose)
-                    if file_date is None or file_date != target_date:
-                        continue
-                stacked_outputs.add(stem)
+        stacked_outputs = find_stack_output_candidates()
 
         claimed_input_stems = set()
         processed_stems_for_remaining = set()
@@ -2799,8 +2845,7 @@ def main():
     if operation_mode == "lightroomimport":
         total_moved = moved_output_count + moved_input_count + remaining_moved_count
         if args.dry_run:
-            action = "copied" if args.leave_on_card else "moved"
-            print(f"DRY RUN complete. {total_moved} files would be {action}.")
+            print(f"DRY RUN complete. {total_moved} files would be {past_tense_verb.lower()}.")
         else:
             throughput_info = ""
             if total_bytes_moved > 0:

--- a/stackcopy.py
+++ b/stackcopy.py
@@ -979,6 +979,8 @@ def main():
     # Add debug flag for stack detection
     parser.add_argument(
         "--debug-stacks",
+        "--debugstacks",
+        dest="debug_stacks",
         action="store_true",
         help="Enable detailed diagnostic output for stack detection",
     )
@@ -988,6 +990,12 @@ def main():
         "--interactive",
         action="store_true",
         help="Show a summary and ask for confirmation before moving files (--lightroomimport only)",
+    )
+
+    parser.add_argument(
+        "--leave-on-card",
+        action="store_true",
+        help="Copy files during --lightroomimport instead of moving them, leaving source files on the card.",
     )
 
     parser.add_argument(
@@ -1067,6 +1075,9 @@ def main():
     ):
         parser.print_help()
         sys.exit(1)
+
+    if args.leave_on_card and args.lightroomimport is None:
+        parser.error("--leave-on-card can only be used with --lightroomimport.")
 
     # Determine operation mode and set directories
     if args.copy:
@@ -1825,9 +1836,15 @@ def main():
                         )
                     )
 
+        file_operation = "copy" if args.leave_on_card else "move"
+        operation_label = "copying" if args.leave_on_card else "moving"
+        planned_action_noun = "copies" if args.leave_on_card else "moves"
+
         # --- Phase B: Disk space preflight (unified) ---
         if planned_moves:
-            ops_for_check = [(m.src_path, m.dest_path, "move") for m in planned_moves]
+            ops_for_check = [
+                (m.src_path, m.dest_path, file_operation) for m in planned_moves
+            ]
             confirm_if_low_space(ops_for_check, args.dry_run)
 
         # --- Phase C: Sort by mtime ascending ---
@@ -1848,7 +1865,10 @@ def main():
         total_rejected = stack_outputs_seen - accepted_stacks
         all_dest_dirs = sorted(set(display_path(m.dest_dir) for m in planned_moves))
 
-        verb = "Would move" if args.dry_run else "Will move"
+        if args.leave_on_card:
+            verb = "Would copy" if args.dry_run else "Will copy"
+        else:
+            verb = "Would move" if args.dry_run else "Will move"
         dry_prefix = "DRY RUN: " if args.dry_run else ""
 
         print(f"\n{dry_prefix}Planned Lightroom import for '{src_dir}':")
@@ -1877,7 +1897,7 @@ def main():
         print(f"  {verb} {planned_output_count} stacked output files")
         print(f"  {verb} {planned_input_count} stack input files")
         print(f"  {verb} {planned_remaining_count} remaining files")
-        print(f"  Total planned moves:           {len(planned_moves)}")
+        print(f"  Total planned {planned_action_noun}:           {len(planned_moves)}")
 
         if skipped_missing_date or skipped_missing_at_plan:
             print()
@@ -1917,7 +1937,7 @@ def main():
                 else:
                     print("Please type y or n.")
 
-        # --- Phase F: Execute moves sequentially ---
+        # --- Phase F: Execute file operations sequentially ---
         exec_start_time = time.perf_counter()
         _emit_progress(phase="start", done=0, total=len(planned_moves))
         # execution_results already initialized at top of main
@@ -1939,17 +1959,17 @@ def main():
         for _move_index, move in enumerate(planned_moves):
             _emit_progress(
                 file=os.path.basename(move.src_path),
-                phase="move",
+                phase=file_operation,
                 done=_move_index,
                 total=_total_planned,
             )
             ensure_directory_once(move.dest_dir, created_dirs, args.dry_run)
 
             success, bytes_moved = safe_file_operation(
-                "move",
+                file_operation,
                 move.src_path,
                 move.dest_path,
-                f"moving {move.category.replace('_', ' ')} file",
+                f"{operation_label} {move.category.replace('_', ' ')} file",
                 args.force,
                 args.dry_run,
             )
@@ -1975,7 +1995,10 @@ def main():
                     remaining_moved_count += 1
 
                 if args.verbose or args.dry_run:
-                    verb = "Would move" if args.dry_run else "Moved"
+                    if args.leave_on_card:
+                        verb = "Would copy" if args.dry_run else "Copied"
+                    else:
+                        verb = "Would move" if args.dry_run else "Moved"
                     dest_short = display_path(move.dest_dir)
                     if move.basename_dest != move.basename_orig:
                         print(
@@ -2066,10 +2089,10 @@ def main():
                         dest_path = os.path.join(dest_dir_import, file_dest_basename)
 
                         success, bytes_moved = safe_file_operation(
-                            "move",
+                            file_operation,
                             file_info["path"],
                             dest_path,
-                            "moving recovered remaining file",
+                            f"{operation_label} recovered remaining file",
                             args.force,
                             args.dry_run,
                         )
@@ -2077,7 +2100,10 @@ def main():
                             total_bytes_moved += bytes_moved
                             remaining_moved_count += 1
                             if args.verbose or args.dry_run:
-                                verb = "Would move" if args.dry_run else "Moved"
+                                if args.leave_on_card:
+                                    verb = "Would copy" if args.dry_run else "Copied"
+                                else:
+                                    verb = "Would move" if args.dry_run else "Moved"
                                 dest_short = display_path(dest_dir_import)
                                 print(
                                     f"{verb} remaining '{file_info['basename']}' as '{file_dest_basename}' -> '{dest_short}'"
@@ -2773,7 +2799,8 @@ def main():
     if operation_mode == "lightroomimport":
         total_moved = moved_output_count + moved_input_count + remaining_moved_count
         if args.dry_run:
-            print(f"DRY RUN complete. {total_moved} files would be moved.")
+            action = "copied" if args.leave_on_card else "moved"
+            print(f"DRY RUN complete. {total_moved} files would be {action}.")
         else:
             throughput_info = ""
             if total_bytes_moved > 0:
@@ -2785,8 +2812,11 @@ def main():
                     f"Data: {total_gb:.1f} GB at {mbps:.1f} MB/s average. "
                 )
 
+            import_action = "Copied" if args.leave_on_card else "Imported"
+            source_note = "Sources left in place. " if args.leave_on_card else ""
             print(
-                f"Done. Imported {total_moved} files in {exec_elapsed_time:.1f}s. "
+                f"Done. {import_action} {total_moved} files in {exec_elapsed_time:.1f}s. "
+                f"{source_note}"
                 f"Breakdown: {moved_output_count} stacked outputs, {moved_input_count} stack inputs, {remaining_moved_count} remaining. "
                 f"{throughput_info}Failures: {failed_count}."
             )

--- a/stackcopy.py
+++ b/stackcopy.py
@@ -1359,7 +1359,16 @@ def main():
                 groups_with_jpg.add(group)
             if has_raw:
                 groups_with_raw.add(group)
-        jpg_only_stack_groups = groups_with_jpg - groups_with_raw
+        for group in groups_with_jpg - groups_with_raw:
+            relative_dir, prefix = group
+            previous_dir = (
+                previous_adjacent_camera_dir(relative_dir, known_relative_dirs_by_key)
+                if scan_recursively
+                else None
+            )
+            if previous_dir and (previous_dir, prefix) in groups_with_raw:
+                continue
+            jpg_only_stack_groups.add(group)
     warned_jpg_only_stack_groups = set()
 
     def describe_stack_detection_group(group):

--- a/stackcopy_gui.py
+++ b/stackcopy_gui.py
@@ -268,12 +268,20 @@ class StackcopyGUI(ctk.CTk):
         opts.grid(row=5, column=0, sticky="w", padx=18, pady=(8, 0))
         self.dry_var = ctk.BooleanVar(value=False)
         self.verbose_var = ctk.BooleanVar(value=False)
+        self.debug_stacks_var = ctk.BooleanVar(value=False)
+        self.leave_on_card_var = ctk.BooleanVar(value=False)
         dry = ctk.CTkCheckBox(opts, text="Dry run (preview only - moves nothing)",
                               variable=self.dry_var, command=self._sync_start_label)
         dry.grid(row=0, column=0, sticky="w")
         verbose = ctk.CTkCheckBox(opts, text="Verbose log", variable=self.verbose_var)
         verbose.grid(row=0, column=1, padx=(24, 0), sticky="w")
-        self._checks += [dry, verbose]
+        debug_stacks = ctk.CTkCheckBox(
+            opts, text="Show stack debug output", variable=self.debug_stacks_var)
+        debug_stacks.grid(row=1, column=0, sticky="w", pady=(8, 0))
+        leave_on_card = ctk.CTkCheckBox(
+            opts, text="Leave files on card", variable=self.leave_on_card_var)
+        leave_on_card.grid(row=1, column=1, padx=(24, 0), sticky="w", pady=(8, 0))
+        self._checks += [dry, verbose, debug_stacks, leave_on_card]
 
         # --- action buttons ---
         actions = ctk.CTkFrame(self, fg_color="transparent")
@@ -417,6 +425,10 @@ class StackcopyGUI(ctk.CTk):
             args.append("--dry")
         if self.verbose_var.get():
             args.append("--verbose")
+        if self.debug_stacks_var.get():
+            args.append("--debug-stacks")
+        if self.leave_on_card_var.get():
+            args.append("--leave-on-card")
         self._pending = (args, dst, stk)
         self._assume_yes = False
         self._launch()
@@ -523,12 +535,16 @@ class StackcopyGUI(ctk.CTk):
             self.status_var.set(
                 "Nothing to import - no matching files found."
                 if total == 0 else f"Importing...  0 / {total}")
-        elif phase == "move":
+        elif phase in {"move", "copy"}:
             self._total = total or self._total
             if self._total:
                 self.progress.set(done / self._total)
+            if self.dry_var.get():
+                action = "Previewing"
+            else:
+                action = "Copying" if self.leave_on_card_var.get() else "Moving"
             self.status_var.set(
-                f"Moving {fname or ''}   ({done} / {self._total})")
+                f"{action} {fname or ''}   ({done} / {self._total})")
         elif phase == "done":
             self.progress.set(1.0 if total else 0)
 
@@ -559,9 +575,10 @@ class StackcopyGUI(ctk.CTk):
             if self._total == 0:
                 self.status_var.set("Nothing to import - no matching files found.")
             elif self.dry_var.get():
-                self.status_var.set("Preview complete - nothing was moved.")
+                self.status_var.set("Preview complete - no files were changed.")
             else:
-                self.status_var.set(f"Import complete - {self._total} files moved.")
+                action = "copied" if self.leave_on_card_var.get() else "moved"
+                self.status_var.set(f"Import complete - {self._total} files {action}.")
                 self.open_btn.configure(state="normal")
         else:
             self.status_var.set(f"stackcopy exited with code {rc} - see log.")

--- a/tests/test_lightroom_jpg_only_guard.py
+++ b/tests/test_lightroom_jpg_only_guard.py
@@ -1,0 +1,155 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STACKCOPY = ROOT / "stackcopy.py"
+
+
+def write_media_file(path: Path, mtime: datetime) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(f"{path.name}\n".encode("ascii"))
+    ts = mtime.timestamp()
+    os.utime(path, (ts, ts))
+
+
+def files_under(path: Path) -> list[Path]:
+    if not path.exists():
+        return []
+    return sorted(p.relative_to(path) for p in path.rglob("*") if p.is_file())
+
+
+class LightroomJpgOnlyGuardTests(unittest.TestCase):
+    def run_stackcopy(self, args: list[str], lightroom: Path, stack_input: Path):
+        env = os.environ.copy()
+        env["STACKCOPY_LIGHTROOM_IMPORT_DIR"] = str(lightroom)
+        env["STACKCOPY_STACK_INPUT_DIR"] = str(stack_input)
+        env["STACKCOPY_ASSUME_YES"] = "1"
+        return subprocess.run(
+            [sys.executable, str(STACKCOPY), *args],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_lightroomimport_jpg_only_repro_imports_all_as_remaining(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src = root / "card"
+            camera_dir = src / "DCIM" / "100OMSYS"
+            lightroom = root / "Lightroom"
+            stack_input = root / "StackInput"
+            base_time = datetime(2026, 6, 17, 12, 0, 0)
+
+            for i in range(1, 37):
+                write_media_file(
+                    camera_dir / f"_617{i:04d}.JPG",
+                    base_time + timedelta(seconds=i),
+                )
+
+            result = self.run_stackcopy(
+                ["--lightroomimport", str(src)], lightroom, stack_input
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("JPG-only import detected", result.stdout)
+            self.assertIn("Stack detection has been disabled", result.stdout)
+            self.assertIn("Stacked JPG candidates found:  0", result.stdout)
+            self.assertIn("Will move 0 stacked output files", result.stdout)
+            self.assertIn("Will move 0 stack input files", result.stdout)
+            self.assertIn("Will move 36 remaining files", result.stdout)
+            self.assertIn(
+                "Breakdown: 0 stacked outputs, 0 stack inputs, 36 remaining",
+                result.stdout,
+            )
+
+            imported = files_under(lightroom)
+            self.assertEqual(len(imported), 36)
+            self.assertEqual(files_under(stack_input), [])
+            self.assertFalse(any("stacked" in p.name.lower() for p in imported))
+            self.assertEqual(files_under(src), [])
+
+    def test_lightroom_jpg_only_repro_does_not_rename_or_move_inputs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src = root / "camera"
+            lightroom = root / "Lightroom"
+            stack_input = root / "StackInput"
+            base_time = datetime(2026, 6, 17, 12, 0, 0)
+
+            for i in range(1, 37):
+                write_media_file(src / f"_617{i:04d}.JPG", base_time)
+
+            result = self.run_stackcopy(["--lightroom", str(src)], lightroom, stack_input)
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("JPG-only import detected", result.stdout)
+            self.assertIn("Done. Processed 0 stacked JPG files", result.stdout)
+            self.assertEqual(len(files_under(src)), 36)
+            self.assertEqual(files_under(stack_input), [])
+            self.assertFalse(any("stacked" in p.name.lower() for p in files_under(src)))
+
+    def test_lightroomimport_raw_jpg_keeps_in_camera_stack_behavior(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src = root / "card"
+            lightroom = root / "Lightroom"
+            stack_input = root / "StackInput"
+            base_time = datetime(2026, 6, 17, 12, 0, 0)
+
+            media_times = {
+                1: base_time,
+                2: base_time + timedelta(seconds=100),
+                3: base_time + timedelta(seconds=102),
+                4: base_time + timedelta(seconds=104),
+                5: base_time + timedelta(seconds=110),
+                6: base_time + timedelta(seconds=220),
+            }
+            for i in (1, 2, 3, 4, 6):
+                write_media_file(src / f"_617{i:04d}.JPG", media_times[i])
+                write_media_file(src / f"_617{i:04d}.ORF", media_times[i])
+            write_media_file(src / "_6170005.JPG", media_times[5])
+
+            result = self.run_stackcopy(
+                ["--lightroomimport", str(src)], lightroom, stack_input
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertNotIn("JPG-only import detected", result.stdout)
+            self.assertIn("Stacked JPG candidates found:  1", result.stdout)
+            self.assertIn("Accepted stacks:               1", result.stdout)
+            self.assertIn(
+                "Breakdown: 1 stacked outputs, 6 stack inputs, 4 remaining",
+                result.stdout,
+            )
+
+            lightroom_files = {p.name for p in files_under(lightroom)}
+            stack_files = {p.name for p in files_under(stack_input)}
+            self.assertIn("_6170005 stacked.JPG", lightroom_files)
+            self.assertEqual(
+                {"_6170001.JPG", "_6170001.ORF", "_6170006.JPG", "_6170006.ORF"},
+                lightroom_files - {"_6170005 stacked.JPG"},
+            )
+            self.assertEqual(
+                {
+                    "_6170002.JPG",
+                    "_6170002.ORF",
+                    "_6170003.JPG",
+                    "_6170003.ORF",
+                    "_6170004.JPG",
+                    "_6170004.ORF",
+                },
+                stack_files,
+            )
+            self.assertEqual(files_under(src), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lightroom_jpg_only_guard.py
+++ b/tests/test_lightroom_jpg_only_guard.py
@@ -150,6 +150,58 @@ class LightroomJpgOnlyGuardTests(unittest.TestCase):
             )
             self.assertEqual(files_under(src), [])
 
+    def test_lightroomimport_preserves_stack_detection_across_roll_folders(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src = root / "card"
+            previous_roll = src / "DCIM" / "100OMSYS"
+            next_roll = src / "DCIM" / "101OMSYS"
+            lightroom = root / "Lightroom"
+            stack_input = root / "StackInput"
+            base_time = datetime(2026, 6, 17, 12, 0, 0)
+
+            frame_times = {
+                9997: base_time,
+                9998: base_time + timedelta(seconds=2),
+                9999: base_time + timedelta(seconds=4),
+            }
+            for number, mtime in frame_times.items():
+                write_media_file(previous_roll / f"_617{number:04d}.JPG", mtime)
+                write_media_file(previous_roll / f"_617{number:04d}.ORF", mtime)
+            write_media_file(
+                next_roll / "_6180000.JPG",
+                base_time + timedelta(seconds=10),
+            )
+
+            result = self.run_stackcopy(
+                ["--lightroomimport", str(src)], lightroom, stack_input
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertNotIn("JPG-only import detected", result.stdout)
+            self.assertIn("Stacked JPG candidates found:  1", result.stdout)
+            self.assertIn("Accepted stacks:               1", result.stdout)
+            self.assertIn(
+                "Breakdown: 1 stacked outputs, 6 stack inputs, 0 remaining",
+                result.stdout,
+            )
+
+            lightroom_files = {p.name for p in files_under(lightroom)}
+            stack_files = {p.name for p in files_under(stack_input)}
+            self.assertEqual({"_6180000 stacked.JPG"}, lightroom_files)
+            self.assertEqual(
+                {
+                    "_6179997.JPG",
+                    "_6179997.ORF",
+                    "_6179998.JPG",
+                    "_6179998.ORF",
+                    "_6179999.JPG",
+                    "_6179999.ORF",
+                },
+                stack_files,
+            )
+            self.assertEqual(files_under(src), [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--leave-on-card` flag to copy files instead of moving during import operations
  * GUI now exposes "Leave files on card" and "Show stack debug output" options
  * Improved stack detection with JPG-only guard to prevent false stacking for JPG-only folders

* **Documentation**
  * Updated README with new CLI options and GUI instructions for import controls

* **Tests**
  * Added comprehensive test coverage for JPG-only stack detection behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->