### PR TITLE
Fix a bug that caused jpg focus brackets to me misinterpreted as stacks

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## **1.5.8 - 2026-07-13**
+
+- Fixed a false-positive stack detection when a JPG-without-RAW candidate appears near the beginning of a long focus bracket and an older photo breaks the backward burst probe.
+- Stack detection now checks for a tight burst continuing immediately after an otherwise valid output candidate.
+- Inputs already claimed by a later valid stack remain a boundary, so rapid consecutive in-camera stacks are not mistaken for one long focus bracket.
+
 ## **1.5.7 - 2026-06-19**
 
 - Added `--version` so installed copies can report their exact Stackcopy version.

--- a/README.md
+++ b/README.md
@@ -278,7 +278,8 @@ For `--lightroom` and `--lightroomimport`, the script does more work to identify
 - Groups files by numeric sequence (e.g., IMG_0100 through IMG_0108)
 - Confirms frames were taken within a short time window of each other (6 seconds between inputs, up to 120 seconds lag for the output)
 - Accepts stacks with 3–15 input frames
-- Rejects sequences with more than 15 consecutive frames within a tight burst window, to avoid moving focus bracketing sets
+- Rejects candidates when a tight burst continues before or after them, to avoid moving focus-bracketing frames even when an older photo breaks the backward scan
+- Treats inputs already claimed by a later valid stack as a stack boundary, preserving rapid consecutive in-camera stacks
 
 Use `--debug-stacks` with `--dry` to see exactly why each stack is accepted or rejected.
 
@@ -309,8 +310,8 @@ If you run stackcopy inside WSL against files under `/mnt/c/`, `/mnt/d/`, etc., 
 
 ## Version
 
-- **Version**: 1.5.7
-- **Date**: June 19, 2026
+- **Version**: 1.5.8
+- **Date**: July 13, 2026
 - **Author**: Alan Rockefeller
 - **Repository**: https://github.com/AlanRockefeller/stackcopy
 - **License**: MIT

--- a/stackcopy.py
+++ b/stackcopy.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
 # SPDX-License-Identifier: MIT
 
-# Stackcopy version 1.5.7 by Alan Rockefeller
-# 6/19/26
+# Stackcopy version 1.5.8 by Alan Rockefeller
+# 7/13/26
 
 # Copies / renames only the photos that have been stacked in-camera - designed for Olympus / OM System, though it might work for other cameras too.
 # Works on Linux, WSL, and Windows.
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from datetime import datetime, date, timedelta
 from typing import Any
 
-STACKCOPY_VERSION = "1.5.7"
+STACKCOPY_VERSION = "1.5.8"
 
 # ---------------------------------------------------------------------------
 # Platform helpers
@@ -1626,6 +1626,57 @@ def main():
                     if args.debug_stacks:
                         print(
                             f"  - Burst Safety Check: TRIGGERED. Found {len(burst_probe_stems)} extra frames within {MAX_BURST_GAP_SECONDS}s of start."
+                        )
+
+        # A backward-only probe misses an output candidate near the beginning
+        # of a long focus bracket.  In that layout the scan can collect a
+        # valid-looking input window, then run into an older unrelated photo
+        # before finding three extra frames.  Look immediately after every
+        # otherwise viable candidate as well: an in-camera stack output ends
+        # its burst, while a focus bracket continues through the candidate.
+        if len(potential_inputs) >= 3 and not too_many_in_burst:
+            forward_probe_stems = []
+            probe_index = idx + 1
+            probe_expected_num = output_num + 1
+
+            while (
+                probe_index < len(sequence)
+                and len(forward_probe_stems) < BURST_EXTRA_FRAMES_REQUIRED
+            ):
+                probe_num, probe_stem = sequence[probe_index]
+                if probe_num != probe_expected_num:
+                    break
+                # Output candidates are processed newest-first.  Claimed
+                # frames here belong to a later stack that was already
+                # accepted, so they are a real stack boundary rather than
+                # evidence that this candidate sits inside one long bracket.
+                if probe_stem in claimed_input_stems:
+                    forward_probe_stems.clear()
+                    break
+                forward_probe_stems.append(probe_stem)
+                probe_expected_num += 1
+                probe_index += 1
+
+            if len(forward_probe_stems) >= BURST_EXTRA_FRAMES_REQUIRED:
+                all_in_burst_gap = True
+                for probe_stem in forward_probe_stems:
+                    probe_mtime = get_stem_mtime(file_db[probe_stem], args.verbose)
+                    if not output_mtime or not probe_mtime:
+                        all_in_burst_gap = False
+                        break
+                    gap = abs((probe_mtime - output_mtime).total_seconds())
+                    if gap > MAX_BURST_GAP_SECONDS:
+                        all_in_burst_gap = False
+                        break
+
+                if all_in_burst_gap:
+                    too_many_in_burst = True
+                    if args.debug_stacks:
+                        print(
+                            "  - Burst Safety Check: TRIGGERED. Burst continues "
+                            "after output candidate with "
+                            f"{len(forward_probe_stems)} frames within "
+                            f"{MAX_BURST_GAP_SECONDS}s."
                         )
 
         input_frames_are_raw_backed = inferred_inputs_are_raw_backed(potential_inputs)

--- a/stackcopy.py
+++ b/stackcopy.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 # Stackcopy version 1.5.8 by Alan Rockefeller
-# 7/13/26
+# 7/14/26
 
 # Copies / renames only the photos that have been stacked in-camera - designed for Olympus / OM System, though it might work for other cameras too.
 # Works on Linux, WSL, and Windows.
@@ -190,7 +190,41 @@ CAMERA_ROLL_DIR_REGEX = re.compile(r"^(\d{3})([A-Za-z0-9_]{5})$")
 MAX_OUTPUT_LAG_SECONDS = 120
 MAX_INPUT_GAP_SECONDS = 6
 MAX_BURST_GAP_SECONDS = 2.0
+MIN_STACK_INPUT_FRAMES = 3
+MAX_STACK_INPUT_FRAMES = 15
 BURST_EXTRA_FRAMES_REQUIRED = 3
+
+
+def collect_consecutive_probe_stems(
+    sequence,
+    *,
+    start_index,
+    expected_num,
+    direction,
+    required_count,
+) -> tuple[str, ...]:
+    """Collect up to ``required_count`` numerically consecutive probe stems.
+
+    ``direction`` is ``-1`` for a backward probe and ``+1`` for a forward
+    probe. Collection stops at sequence bounds or the first numeric gap.
+    """
+    if direction not in (-1, 1):
+        raise ValueError("direction must be -1 or +1")
+    if required_count < 0:
+        raise ValueError("required_count must be non-negative")
+
+    stems = []
+    probe_index = start_index
+    probe_expected_num = expected_num
+    while 0 <= probe_index < len(sequence) and len(stems) < required_count:
+        probe_num, probe_stem = sequence[probe_index]
+        if probe_num != probe_expected_num:
+            break
+        stems.append(probe_stem)
+        probe_expected_num += direction
+        probe_index += direction
+
+    return tuple(stems)
 
 
 @dataclass
@@ -1505,51 +1539,44 @@ def main():
         allowed_gap = MAX_OUTPUT_LAG_SECONDS
         gap_type = "output_lag"
 
-        while current_index >= 0 and len(potential_inputs) < 15:
+        while current_index >= 0 and len(potential_inputs) < MAX_STACK_INPUT_FRAMES:
             candidate_num, candidate_stem = sequence[current_index]
             candidate_record = file_db[candidate_stem]
 
             if candidate_num != expected_num:
-                stop_reason = f"Number mismatch (expected {expected_num}, found {candidate_num})"
+                stop_reason = (
+                    f"Number mismatch (expected {expected_num}, found {candidate_num})"
+                )
                 if args.debug_stacks:
-                    print(
-                        f"    - Input '{candidate_stem}': REJECTED ({stop_reason})"
-                    )
+                    print(f"    - Input '{candidate_stem}': REJECTED ({stop_reason})")
                 break
 
             if candidate_stem in claimed_input_stems:
                 stop_reason = "Already claimed by another stack"
                 if args.debug_stacks:
-                    print(
-                        f"    - Input '{candidate_stem}': REJECTED ({stop_reason})"
-                    )
+                    print(f"    - Input '{candidate_stem}': REJECTED ({stop_reason})")
                 break
 
-            if not (
-                candidate_record.get("has_raw") or candidate_record.get("has_jpg")
-            ):
+            if not (candidate_record.get("has_raw") or candidate_record.get("has_jpg")):
                 stop_reason = "No corresponding RAW or JPG file found"
                 if args.debug_stacks:
-                    print(
-                        f"    - Input '{candidate_stem}': REJECTED ({stop_reason})"
-                    )
+                    print(f"    - Input '{candidate_stem}': REJECTED ({stop_reason})")
                 break
 
-            if not candidate_record.get("has_raw") and len(potential_inputs) >= 3:
+            if (
+                not candidate_record.get("has_raw")
+                and len(potential_inputs) >= MIN_STACK_INPUT_FRAMES
+            ):
                 stop_reason = "Non-RAW-backed boundary after sufficient inputs"
                 if args.debug_stacks:
-                    print(
-                        f"    - Input '{candidate_stem}': STOPPED ({stop_reason})"
-                    )
+                    print(f"    - Input '{candidate_stem}': STOPPED ({stop_reason})")
                 break
 
             input_mtime = get_stem_mtime(candidate_record, args.verbose)
 
             has_valid_raw_mtime = False
             if candidate_record.get("has_raw"):
-                raw_mtime_val = get_file_mtime(
-                    candidate_record["files"]["raw"], False
-                )
+                raw_mtime_val = get_file_mtime(candidate_record["files"]["raw"], False)
                 if raw_mtime_val:
                     has_valid_raw_mtime = True
 
@@ -1563,9 +1590,7 @@ def main():
             if time_gap > allowed_gap:
                 stop_reason = f"Time gap too large ({time_gap:.2f}s > {allowed_gap}s, type: {gap_type})"
                 if args.debug_stacks:
-                    print(
-                        f"    - Input '{candidate_stem}': REJECTED ({stop_reason})"
-                    )
+                    print(f"    - Input '{candidate_stem}': REJECTED ({stop_reason})")
                 break
 
             if args.debug_stacks:
@@ -1581,28 +1606,25 @@ def main():
             expected_num -= 1
             current_index -= 1
 
-        if len(potential_inputs) == 15:
+        if len(potential_inputs) == MAX_STACK_INPUT_FRAMES:
             hit_input_cap = True
             if args.debug_stacks:
-                print("  - Note: Reached 15-frame input cap.")
+                print(f"  - Note: Reached {MAX_STACK_INPUT_FRAMES}-frame input cap.")
 
-        # Burst safety check
+        # A JPEG-only output plus consecutive RAW-backed preceding frames is
+        # the primary stack evidence. Following photos are not part of this
+        # candidate and are deliberately ignored. Only probe farther backward
+        # after hitting the camera's maximum input count, to catch an apparent
+        # continuous sequence extending beyond that supported stack size.
         too_many_in_burst = False
         if potential_inputs and hit_input_cap:
-            burst_probe_stems = []
-            probe_index = current_index
-            probe_expected_num = expected_num
-
-            while (
-                probe_index >= 0
-                and len(burst_probe_stems) < BURST_EXTRA_FRAMES_REQUIRED
-            ):
-                probe_num, probe_stem = sequence[probe_index]
-                if probe_num != probe_expected_num:
-                    break
-                burst_probe_stems.append(probe_stem)
-                probe_expected_num -= 1
-                probe_index -= 1
+            burst_probe_stems = collect_consecutive_probe_stems(
+                sequence,
+                start_index=current_index,
+                expected_num=expected_num,
+                direction=-1,
+                required_count=BURST_EXTRA_FRAMES_REQUIRED,
+            )
 
             if len(burst_probe_stems) >= BURST_EXTRA_FRAMES_REQUIRED:
                 first_input_stem = potential_inputs[-1]
@@ -1626,57 +1648,6 @@ def main():
                     if args.debug_stacks:
                         print(
                             f"  - Burst Safety Check: TRIGGERED. Found {len(burst_probe_stems)} extra frames within {MAX_BURST_GAP_SECONDS}s of start."
-                        )
-
-        # A backward-only probe misses an output candidate near the beginning
-        # of a long focus bracket.  In that layout the scan can collect a
-        # valid-looking input window, then run into an older unrelated photo
-        # before finding three extra frames.  Look immediately after every
-        # otherwise viable candidate as well: an in-camera stack output ends
-        # its burst, while a focus bracket continues through the candidate.
-        if len(potential_inputs) >= 3 and not too_many_in_burst:
-            forward_probe_stems = []
-            probe_index = idx + 1
-            probe_expected_num = output_num + 1
-
-            while (
-                probe_index < len(sequence)
-                and len(forward_probe_stems) < BURST_EXTRA_FRAMES_REQUIRED
-            ):
-                probe_num, probe_stem = sequence[probe_index]
-                if probe_num != probe_expected_num:
-                    break
-                # Output candidates are processed newest-first.  Claimed
-                # frames here belong to a later stack that was already
-                # accepted, so they are a real stack boundary rather than
-                # evidence that this candidate sits inside one long bracket.
-                if probe_stem in claimed_input_stems:
-                    forward_probe_stems.clear()
-                    break
-                forward_probe_stems.append(probe_stem)
-                probe_expected_num += 1
-                probe_index += 1
-
-            if len(forward_probe_stems) >= BURST_EXTRA_FRAMES_REQUIRED:
-                all_in_burst_gap = True
-                for probe_stem in forward_probe_stems:
-                    probe_mtime = get_stem_mtime(file_db[probe_stem], args.verbose)
-                    if not output_mtime or not probe_mtime:
-                        all_in_burst_gap = False
-                        break
-                    gap = abs((probe_mtime - output_mtime).total_seconds())
-                    if gap > MAX_BURST_GAP_SECONDS:
-                        all_in_burst_gap = False
-                        break
-
-                if all_in_burst_gap:
-                    too_many_in_burst = True
-                    if args.debug_stacks:
-                        print(
-                            "  - Burst Safety Check: TRIGGERED. Burst continues "
-                            "after output candidate with "
-                            f"{len(forward_probe_stems)} frames within "
-                            f"{MAX_BURST_GAP_SECONDS}s."
                         )
 
         input_frames_are_raw_backed = inferred_inputs_are_raw_backed(potential_inputs)
@@ -1803,16 +1774,27 @@ def main():
 
             # Final decision on the stack
             is_valid_stack = (
-                3 <= len(potential_inputs) <= 15
-            ) and not too_many_in_burst and not inputs_not_all_raw_backed
+                (
+                    MIN_STACK_INPUT_FRAMES
+                    <= len(potential_inputs)
+                    <= MAX_STACK_INPUT_FRAMES
+                )
+                and not too_many_in_burst
+                and not inputs_not_all_raw_backed
+            )
 
             if args.debug_stacks:
                 print(
                     f"  - Final Decision: {'ACCEPTED' if is_valid_stack else 'REJECTED'}"
                 )
-                if not (3 <= len(potential_inputs) <= 15):
+                if not (
+                    MIN_STACK_INPUT_FRAMES
+                    <= len(potential_inputs)
+                    <= MAX_STACK_INPUT_FRAMES
+                ):
                     print(
-                        f"    - Reason: Found {len(potential_inputs)} inputs, but requires 3-15."
+                        f"    - Reason: Found {len(potential_inputs)} inputs, but requires "
+                        f"{MIN_STACK_INPUT_FRAMES}-{MAX_STACK_INPUT_FRAMES}."
                     )
                 if too_many_in_burst:
                     print(
@@ -1824,7 +1806,9 @@ def main():
 
             if not is_valid_stack:
                 if not inputs_not_all_raw_backed and not (
-                    3 <= len(potential_inputs) <= 15
+                    MIN_STACK_INPUT_FRAMES
+                    <= len(potential_inputs)
+                    <= MAX_STACK_INPUT_FRAMES
                 ):
                     rejected_too_few_inputs += 1
                 if too_many_in_burst:
@@ -2071,7 +2055,9 @@ def main():
         past_tense_verb = "Copied" if args.leave_on_card else "Moved"
         # "Would copy"/"Will copy" for the plan summary, "Would copy"/"Copied"
         # for per-file execution lines (and likewise for moves).
-        planned_verb = f"Would {file_operation}" if args.dry_run else f"Will {file_operation}"
+        planned_verb = (
+            f"Would {file_operation}" if args.dry_run else f"Will {file_operation}"
+        )
         done_verb = f"Would {file_operation}" if args.dry_run else past_tense_verb
 
         # --- Phase B: Disk space preflight (unified) ---
@@ -2430,16 +2416,27 @@ def main():
             )
 
             is_valid_stack = (
-                3 <= len(potential_inputs) <= 15
-            ) and not too_many_in_burst and not inputs_not_all_raw_backed
+                (
+                    MIN_STACK_INPUT_FRAMES
+                    <= len(potential_inputs)
+                    <= MAX_STACK_INPUT_FRAMES
+                )
+                and not too_many_in_burst
+                and not inputs_not_all_raw_backed
+            )
 
             if args.debug_stacks:
                 print(
                     f"  - Final Decision: {'ACCEPTED' if is_valid_stack else 'REJECTED'}"
                 )
-                if not (3 <= len(potential_inputs) <= 15):
+                if not (
+                    MIN_STACK_INPUT_FRAMES
+                    <= len(potential_inputs)
+                    <= MAX_STACK_INPUT_FRAMES
+                ):
                     print(
-                        f"    - Reason: Found {len(potential_inputs)} inputs, but requires 3-15."
+                        f"    - Reason: Found {len(potential_inputs)} inputs, but requires "
+                        f"{MIN_STACK_INPUT_FRAMES}-{MAX_STACK_INPUT_FRAMES}."
                     )
                 if too_many_in_burst:
                     print(
@@ -2903,7 +2900,9 @@ def main():
     if operation_mode == "lightroomimport":
         total_moved = moved_output_count + moved_input_count + remaining_moved_count
         if args.dry_run:
-            print(f"DRY RUN complete. {total_moved} files would be {past_tense_verb.lower()}.")
+            print(
+                f"DRY RUN complete. {total_moved} files would be {past_tense_verb.lower()}."
+            )
         else:
             throughput_info = ""
             if total_bytes_moved > 0:

--- a/stackcopy_cli.py
+++ b/stackcopy_cli.py
@@ -6,6 +6,5 @@ from __future__ import annotations
 
 import stackcopy
 
-
 if __name__ == "__main__":
     stackcopy.main()

--- a/stackcopy_gui.py
+++ b/stackcopy_gui.py
@@ -25,7 +25,6 @@ import threading
 import subprocess
 from pathlib import Path
 
-
 # ---------------------------------------------------------------------------
 # Frozen-app CLI dispatch
 # ---------------------------------------------------------------------------
@@ -44,7 +43,6 @@ if os.environ.get("STACKCOPY_RUN_CLI") == "1":
 
 import customtkinter as ctk  # noqa: E402  (must follow the CLI dispatch above)
 from tkinter import filedialog, messagebox  # noqa: E402
-
 
 PROGRESS_SENTINEL = "@@SCPROGRESS"
 LOW_SPACE_SENTINEL = "@@SCLOWSPACE"
@@ -99,14 +97,14 @@ def parse_progress(line: str) -> tuple[dict[str, str], str | None]:
 
     ``file=`` is always last and may contain spaces, so it is split off before
     the remaining ``key=value`` tokens are parsed."""
-    body = line[len(PROGRESS_SENTINEL):].strip()
+    body = line[len(PROGRESS_SENTINEL) :].strip()
     fname: str | None = None
     marker = " file="
     if marker in body:
         body, fname = body.split(marker, 1)
         fname = fname.strip()
     elif body.startswith("file="):
-        fname = body[len("file="):].strip()
+        fname = body[len("file=") :].strip()
         body = ""
     fields: dict[str, str] = {}
     for tok in body.split():
@@ -118,7 +116,7 @@ def parse_progress(line: str) -> tuple[dict[str, str], str | None]:
 
 def parse_low_space_report(line: str) -> dict[str, object] | None:
     try:
-        payload = json.loads(line[len(LOW_SPACE_SENTINEL):].strip())
+        payload = json.loads(line[len(LOW_SPACE_SENTINEL) :].strip())
     except (json.JSONDecodeError, TypeError, ValueError):
         return None
     return payload if isinstance(payload, dict) else None
@@ -236,14 +234,19 @@ class StackcopyGUI(ctk.CTk):
 
         # --- header ---
         ctk.CTkLabel(
-            self, text="Lightroom Import",
+            self,
+            text="Lightroom Import",
             font=ctk.CTkFont(size=22, weight="bold"),
         ).grid(row=0, column=0, sticky="w", padx=18, pady=(16, 0))
         ctk.CTkLabel(
             self,
-            text=("Sort an Olympus / OM-System card into your Lightroom library, "
-                  "separating the in-camera stack frames from everything else."),
-            text_color=("gray40", "gray70"), wraplength=720, justify="left",
+            text=(
+                "Sort an Olympus / OM-System card into your Lightroom library, "
+                "separating the in-camera stack frames from everything else."
+            ),
+            text_color=("gray40", "gray70"),
+            wraplength=720,
+            justify="left",
         ).grid(row=1, column=0, sticky="w", padx=18, pady=(2, 6))
 
         # --- folder pickers ---
@@ -256,12 +259,24 @@ class StackcopyGUI(ctk.CTk):
         self.dst_var.trace_add("write", self._on_settings_changed)
         self.stk_var.trace_add("write", self._on_settings_changed)
 
-        self._dir_row(2, "Source (camera card)", self.src_var,
-                      "Folder to import from - your SD card, or its DCIM folder")
-        self._dir_row(3, "Lightroom destination", self.dst_var,
-                      "Stacked outputs, single shots, and videos go here")
-        self._dir_row(4, "Stack input frames", self.stk_var,
-                      "The raw frames that fed each in-camera stack go here")
+        self._dir_row(
+            2,
+            "Source (camera card)",
+            self.src_var,
+            "Folder to import from - your SD card, or its DCIM folder",
+        )
+        self._dir_row(
+            3,
+            "Lightroom destination",
+            self.dst_var,
+            "Stacked outputs, single shots, and videos go here",
+        )
+        self._dir_row(
+            4,
+            "Stack input frames",
+            self.stk_var,
+            "The raw frames that fed each in-camera stack go here",
+        )
 
         # --- options ---
         opts = ctk.CTkFrame(self, fg_color="transparent")
@@ -271,19 +286,26 @@ class StackcopyGUI(ctk.CTk):
         self.detect_stacks_var = ctk.BooleanVar(value=True)
         self.debug_stacks_var = ctk.BooleanVar(value=False)
         self.leave_on_card_var = ctk.BooleanVar(value=False)
-        dry = ctk.CTkCheckBox(opts, text="Dry run (preview only - moves nothing)",
-                              variable=self.dry_var, command=self._sync_start_label)
+        dry = ctk.CTkCheckBox(
+            opts,
+            text="Dry run (preview only - moves nothing)",
+            variable=self.dry_var,
+            command=self._sync_start_label,
+        )
         dry.grid(row=0, column=0, sticky="w")
         verbose = ctk.CTkCheckBox(opts, text="Verbose log", variable=self.verbose_var)
         verbose.grid(row=0, column=1, padx=(24, 0), sticky="w")
         detect_stacks = ctk.CTkCheckBox(
-            opts, text="Detect stacks", variable=self.detect_stacks_var)
+            opts, text="Detect stacks", variable=self.detect_stacks_var
+        )
         detect_stacks.grid(row=1, column=0, sticky="w", pady=(8, 0))
         debug_stacks = ctk.CTkCheckBox(
-            opts, text="Show stack debug output", variable=self.debug_stacks_var)
+            opts, text="Show stack debug output", variable=self.debug_stacks_var
+        )
         debug_stacks.grid(row=1, column=1, padx=(24, 0), sticky="w", pady=(8, 0))
         leave_on_card = ctk.CTkCheckBox(
-            opts, text="Leave files on card", variable=self.leave_on_card_var)
+            opts, text="Leave files on card", variable=self.leave_on_card_var
+        )
         leave_on_card.grid(row=2, column=0, sticky="w", pady=(8, 0))
         self._checks += [dry, verbose, detect_stacks, debug_stacks, leave_on_card]
 
@@ -291,16 +313,31 @@ class StackcopyGUI(ctk.CTk):
         actions = ctk.CTkFrame(self, fg_color="transparent")
         actions.grid(row=6, column=0, sticky="we", padx=18, pady=(14, 0))
         actions.grid_columnconfigure(2, weight=1)
-        self.start_btn = ctk.CTkButton(actions, text="Start import", width=170,
-                                       height=38, command=self._on_start)
+        self.start_btn = ctk.CTkButton(
+            actions, text="Start import", width=170, height=38, command=self._on_start
+        )
         self.start_btn.grid(row=0, column=0)
-        self.cancel_btn = ctk.CTkButton(actions, text="Cancel", width=100, height=38,
-                                        fg_color="gray38", hover_color="gray30",
-                                        state="disabled", command=self._on_cancel)
+        self.cancel_btn = ctk.CTkButton(
+            actions,
+            text="Cancel",
+            width=100,
+            height=38,
+            fg_color="gray38",
+            hover_color="gray30",
+            state="disabled",
+            command=self._on_cancel,
+        )
         self.cancel_btn.grid(row=0, column=1, padx=(10, 0))
-        self.open_btn = ctk.CTkButton(actions, text="Open destination", width=160,
-                                      height=38, fg_color="transparent", border_width=1,
-                                      state="disabled", command=self._open_dest)
+        self.open_btn = ctk.CTkButton(
+            actions,
+            text="Open destination",
+            width=160,
+            height=38,
+            fg_color="transparent",
+            border_width=1,
+            state="disabled",
+            command=self._open_dest,
+        )
         self.open_btn.grid(row=0, column=3, sticky="e")
 
         # --- progress + status ---
@@ -309,12 +346,14 @@ class StackcopyGUI(ctk.CTk):
         self.progress.set(0)
         self.status_var = ctk.StringVar(value="Ready.")
         ctk.CTkLabel(self, textvariable=self.status_var, anchor="w").grid(
-            row=8, column=0, sticky="we", padx=18, pady=(4, 0))
+            row=8, column=0, sticky="we", padx=18, pady=(4, 0)
+        )
 
         # --- log ---
         self.grid_rowconfigure(9, weight=1)
-        self.log = ctk.CTkTextbox(self, wrap="none",
-                                  font=ctk.CTkFont(family=_mono_family(), size=12))
+        self.log = ctk.CTkTextbox(
+            self, wrap="none", font=ctk.CTkFont(family=_mono_family(), size=12)
+        )
         self.log.grid(row=9, column=0, sticky="nsew", padx=18, pady=(8, 16))
         self.log.configure(state="disabled")
 
@@ -328,18 +367,23 @@ class StackcopyGUI(ctk.CTk):
         frame = ctk.CTkFrame(self, fg_color="transparent")
         frame.grid(row=row, column=0, sticky="we", padx=18, pady=(8, 0))
         frame.grid_columnconfigure(0, weight=1)
-        ctk.CTkLabel(frame, text=label, anchor="w",
-                     font=ctk.CTkFont(weight="bold")).grid(
-            row=0, column=0, columnspan=2, sticky="w")
+        ctk.CTkLabel(
+            frame, text=label, anchor="w", font=ctk.CTkFont(weight="bold")
+        ).grid(row=0, column=0, columnspan=2, sticky="w")
         entry = ctk.CTkEntry(frame, textvariable=var)
         entry.grid(row=1, column=0, sticky="we", pady=(2, 0))
-        browse = ctk.CTkButton(frame, text="Browse...", width=92,
-                               command=lambda v=var: self._browse(v))
+        browse = ctk.CTkButton(
+            frame, text="Browse...", width=92, command=lambda v=var: self._browse(v)
+        )
         browse.grid(row=1, column=1, padx=(8, 0), pady=(2, 0))
-        ctk.CTkLabel(frame, text=hint, anchor="w", justify="left",
-                     text_color=("gray45", "gray60"),
-                     font=ctk.CTkFont(size=11)).grid(
-            row=2, column=0, columnspan=2, sticky="w")
+        ctk.CTkLabel(
+            frame,
+            text=hint,
+            anchor="w",
+            justify="left",
+            text_color=("gray45", "gray60"),
+            font=ctk.CTkFont(size=11),
+        ).grid(row=2, column=0, columnspan=2, sticky="w")
         self._entries.append(entry)
         self._browse_btns.append(browse)
 
@@ -371,16 +415,19 @@ class StackcopyGUI(ctk.CTk):
 
     def _save_current_defaults(self) -> None:
         self._save_state_scheduled = False
-        save_gui_state({
-            "source_dir": self.src_var.get(),
-            "lightroom_dir": self.dst_var.get(),
-            "stack_input_dir": self.stk_var.get(),
-        })
+        save_gui_state(
+            {
+                "source_dir": self.src_var.get(),
+                "lightroom_dir": self.dst_var.get(),
+                "stack_input_dir": self.stk_var.get(),
+            }
+        )
 
     def _sync_start_label(self) -> None:
         if not self._running:
             self.start_btn.configure(
-                text="Preview (dry run)" if self.dry_var.get() else "Start import")
+                text="Preview (dry run)" if self.dry_var.get() else "Start import"
+            )
 
     def _log_write(self, text: str) -> None:
         self.log.configure(state="normal")
@@ -415,13 +462,13 @@ class StackcopyGUI(ctk.CTk):
             messagebox.showerror("Stackcopy", "Please choose a valid source folder.")
             return
         if not dst or not stk:
-            messagebox.showerror(
-                "Stackcopy", "Please choose both destination folders.")
+            messagebox.showerror("Stackcopy", "Please choose both destination folders.")
             return
         if os.path.abspath(dst) == os.path.abspath(stk):
             messagebox.showerror(
                 "Stackcopy",
-                "The Lightroom destination and stack-input folder must be different.")
+                "The Lightroom destination and stack-input folder must be different.",
+            )
             return
 
         args = ["--lightroomimport", src]
@@ -473,11 +520,16 @@ class StackcopyGUI(ctk.CTk):
             creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
         try:
             proc = subprocess.Popen(
-                cmd, env=env,
+                cmd,
+                env=env,
                 stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                text=True, encoding="utf-8", errors="replace",
-                bufsize=1, creationflags=creationflags,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                bufsize=1,
+                creationflags=creationflags,
             )
         except Exception as exc:  # noqa: BLE001 - surfaced to the user
             self._queue.put(("fatal", f"Could not start stackcopy: {exc}\n"))
@@ -512,7 +564,9 @@ class StackcopyGUI(ctk.CTk):
                         self._handle_progress(payload)
                     elif payload.startswith(LOW_SPACE_SENTINEL):
                         self._low_space_report = parse_low_space_report(payload)
-                        self.status_var.set("Low disk space - waiting for confirmation.")
+                        self.status_var.set(
+                            "Low disk space - waiting for confirmation."
+                        )
                     else:
                         self._log_write(payload)
                 elif kind == "fatal":
@@ -540,7 +594,9 @@ class StackcopyGUI(ctk.CTk):
             self.progress.set(0)
             self.status_var.set(
                 "Nothing to import - no matching files found."
-                if total == 0 else f"Importing...  0 / {total}")
+                if total == 0
+                else f"Importing...  0 / {total}"
+            )
         elif phase in {"move", "copy"}:
             self._total = total or self._total
             if self._total:
@@ -549,8 +605,7 @@ class StackcopyGUI(ctk.CTk):
                 action = "Previewing"
             else:
                 action = "Copying" if self.leave_on_card_var.get() else "Moving"
-            self.status_var.set(
-                f"{action} {fname or ''}   ({done} / {self._total})")
+            self.status_var.set(f"{action} {fname or ''}   ({done} / {self._total})")
         elif phase == "done":
             self.progress.set(1.0 if total else 0)
 
@@ -647,7 +702,8 @@ class StackcopyGUI(ctk.CTk):
         proc = self._proc
         if proc and proc.poll() is None:
             if not messagebox.askyesno(
-                "Quit", "An import is still running. Stop it and quit?"):
+                "Quit", "An import is still running. Stop it and quit?"
+            ):
                 return
             self.status_var.set("Stopping import...")
             if not self._terminate_process(proc, "stop"):

--- a/tests/test_lightroom_jpg_only_guard.py
+++ b/tests/test_lightroom_jpg_only_guard.py
@@ -1,13 +1,20 @@
+import io
 import os
 import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from datetime import datetime, timedelta
 from pathlib import Path
-
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import stackcopy as stackcopy_module  # noqa: E402
+from stackcopy import collect_consecutive_probe_stems  # noqa: E402
+
 STACKCOPY = ROOT / "stackcopy.py"
 
 
@@ -22,6 +29,89 @@ def files_under(path: Path) -> list[Path]:
     if not path.exists():
         return []
     return sorted(p.relative_to(path) for p in path.rglob("*") if p.is_file())
+
+
+class ConsecutiveProbeTests(unittest.TestCase):
+    def test_collects_forward_and_backward_until_numeric_discontinuity(self):
+        sequence = [
+            (10, "frame10"),
+            (11, "frame11"),
+            (13, "frame13"),
+            (14, "frame14"),
+        ]
+
+        forward = collect_consecutive_probe_stems(
+            sequence,
+            start_index=0,
+            expected_num=10,
+            direction=1,
+            required_count=4,
+        )
+        backward = collect_consecutive_probe_stems(
+            sequence,
+            start_index=3,
+            expected_num=14,
+            direction=-1,
+            required_count=4,
+        )
+
+        self.assertEqual(forward, ("frame10", "frame11"))
+        self.assertEqual(backward, ("frame14", "frame13"))
+
+    def test_sequence_bounds_and_short_probe_return_partial_collection(self):
+        sequence = [(20, "frame20"), (21, "frame21")]
+
+        before_start = collect_consecutive_probe_stems(
+            sequence,
+            start_index=-1,
+            expected_num=19,
+            direction=-1,
+            required_count=3,
+        )
+        after_end = collect_consecutive_probe_stems(
+            sequence,
+            start_index=len(sequence),
+            expected_num=22,
+            direction=1,
+            required_count=3,
+        )
+        short_forward = collect_consecutive_probe_stems(
+            sequence,
+            start_index=0,
+            expected_num=20,
+            direction=1,
+            required_count=3,
+        )
+        short_backward = collect_consecutive_probe_stems(
+            sequence,
+            start_index=1,
+            expected_num=21,
+            direction=-1,
+            required_count=3,
+        )
+
+        self.assertEqual(before_start, ())
+        self.assertEqual(after_end, ())
+        self.assertEqual(short_forward, ("frame20", "frame21"))
+        self.assertEqual(short_backward, ("frame21", "frame20"))
+
+    def test_probe_arguments_are_validated(self):
+        with self.assertRaisesRegex(ValueError, r"direction must be -1 or \+1"):
+            collect_consecutive_probe_stems(
+                [(1, "frame1")],
+                start_index=0,
+                expected_num=1,
+                direction=0,
+                required_count=1,
+            )
+        with self.assertRaisesRegex(ValueError, "required_count must be non-negative"):
+            collect_consecutive_probe_stems(
+                [(1, "frame1")],
+                start_index=0,
+                expected_num=1,
+                direction=1,
+                required_count=-1,
+            )
 
 
 class LightroomJpgOnlyGuardTests(unittest.TestCase):
@@ -99,7 +189,9 @@ class LightroomJpgOnlyGuardTests(unittest.TestCase):
             for i in range(1, 27):
                 write_media_file(src / f"_617{i:04d}.JPG", base_time)
 
-            result = self.run_stackcopy(["--lightroom", str(src)], lightroom, stack_input)
+            result = self.run_stackcopy(
+                ["--lightroom", str(src)], lightroom, stack_input
+            )
 
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
             self.assertIn("JPG-only import detected", result.stdout)
@@ -162,6 +254,157 @@ class LightroomJpgOnlyGuardTests(unittest.TestCase):
             )
             self.assertEqual(files_under(src), [])
 
+    def test_valid_stack_followed_by_quick_ordinary_burst_in_both_modes(self):
+        """Following photos never participate in the output candidate decision."""
+        for mode in ("--lightroom", "--lightroomimport"):
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                src = root / "card"
+                lightroom = root / "Lightroom"
+                stack_input = root / "StackInput"
+                base_time = datetime(2026, 7, 14, 12, 0, 0)
+
+                for number in range(1, 7):
+                    mtime = base_time + timedelta(milliseconds=number * 100)
+                    write_media_file(src / f"_714{number:04d}.JPG", mtime)
+                    write_media_file(src / f"_714{number:04d}.ORF", mtime)
+
+                output_time = base_time + timedelta(milliseconds=700)
+                write_media_file(src / "_7140007.JPG", output_time)
+
+                following_names = set()
+                for number in range(8, 12):
+                    mtime = base_time + timedelta(milliseconds=number * 100)
+                    for extension in ("JPG", "ORF"):
+                        name = f"_714{number:04d}.{extension}"
+                        following_names.add(name)
+                        write_media_file(src / name, mtime)
+
+                result = self.run_stackcopy(
+                    [mode, str(src), "--debug-stacks"], lightroom, stack_input
+                )
+
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertNotIn("Burst Safety Check: TRIGGERED", result.stdout)
+                self.assertIn("Final Decision: ACCEPTED", result.stdout)
+
+                expected_inputs = {
+                    f"_714{number:04d}.{extension}"
+                    for number in range(1, 7)
+                    for extension in ("JPG", "ORF")
+                }
+                self.assertEqual(
+                    expected_inputs,
+                    {path.name for path in files_under(stack_input)},
+                )
+
+                output_name = "_7140007 stacked.JPG"
+                if mode == "--lightroomimport":
+                    self.assertIn("Accepted stacks:               1", result.stdout)
+                    self.assertIn(
+                        "Breakdown: 1 stacked outputs, 12 stack inputs, 8 remaining",
+                        result.stdout,
+                    )
+                    self.assertEqual(
+                        following_names | {output_name},
+                        {path.name for path in files_under(lightroom)},
+                    )
+                    self.assertEqual(files_under(src), [])
+                else:
+                    self.assertEqual(
+                        following_names | {output_name},
+                        {path.name for path in files_under(src)},
+                    )
+                    self.assertEqual(files_under(lightroom), [])
+
+    def test_maximum_size_stack_followed_by_rapid_photos_is_accepted(self):
+        """Trust the intact camera file model even when all mtimes are continuous."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src = root / "card"
+            lightroom = root / "Lightroom"
+            stack_input = root / "StackInput"
+            base_time = datetime(2026, 7, 14, 13, 0, 0)
+
+            for number in range(1, 16):
+                mtime = base_time + timedelta(milliseconds=number * 100)
+                write_media_file(src / f"_715{number:04d}.JPG", mtime)
+                write_media_file(src / f"_715{number:04d}.ORF", mtime)
+            write_media_file(
+                src / "_7150016.JPG",
+                base_time + timedelta(milliseconds=1600),
+            )
+            following_names = set()
+            for number in range(17, 21):
+                mtime = base_time + timedelta(milliseconds=number * 100)
+                for extension in ("JPG", "ORF"):
+                    name = f"_715{number:04d}.{extension}"
+                    following_names.add(name)
+                    write_media_file(src / name, mtime)
+
+            result = self.run_stackcopy(
+                ["--lightroomimport", str(src), "--debug-stacks"],
+                lightroom,
+                stack_input,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertNotIn("Burst Safety Check: TRIGGERED", result.stdout)
+            self.assertIn("Accepted stacks:               1", result.stdout)
+            self.assertIn(
+                "Breakdown: 1 stacked outputs, 30 stack inputs, 8 remaining",
+                result.stdout,
+            )
+            self.assertEqual(
+                following_names | {"_7150016 stacked.JPG"},
+                {path.name for path in files_under(lightroom)},
+            )
+            self.assertEqual(
+                {
+                    f"_715{number:04d}.{extension}"
+                    for number in range(1, 16)
+                    for extension in ("JPG", "ORF")
+                },
+                {path.name for path in files_under(stack_input)},
+            )
+            self.assertEqual(files_under(src), [])
+
+    def test_normal_shorter_stack_without_following_photos_is_accepted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src = root / "card"
+            lightroom = root / "Lightroom"
+            stack_input = root / "StackInput"
+            base_time = datetime(2026, 7, 14, 13, 30, 0)
+
+            for number in range(1, 6):
+                mtime = base_time + timedelta(milliseconds=number * 200)
+                write_media_file(src / f"_7155{number:03d}.JPG", mtime)
+                write_media_file(src / f"_7155{number:03d}.ORF", mtime)
+            write_media_file(
+                src / "_7155006.JPG",
+                base_time + timedelta(milliseconds=1200),
+            )
+
+            result = self.run_stackcopy(
+                ["--lightroomimport", str(src), "--debug-stacks"],
+                lightroom,
+                stack_input,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("Accepted stacks:               1", result.stdout)
+            self.assertIn(
+                "Breakdown: 1 stacked outputs, 10 stack inputs, 0 remaining",
+                result.stdout,
+            )
+            self.assertEqual(
+                {"_7155006 stacked.JPG"},
+                {path.name for path in files_under(lightroom)},
+            )
+            self.assertEqual(10, len(files_under(stack_input)))
+            self.assertEqual(files_under(src), [])
+
     def test_lightroomimport_quick_consecutive_stacks_stop_at_prior_output(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -193,8 +436,12 @@ class LightroomJpgOnlyGuardTests(unittest.TestCase):
             )
 
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-            self.assertNotIn("inferred input frames are not all RAW-backed", result.stdout)
-            self.assertIn("Non-RAW-backed boundary after sufficient inputs", result.stdout)
+            self.assertNotIn(
+                "inferred input frames are not all RAW-backed", result.stdout
+            )
+            self.assertIn(
+                "Non-RAW-backed boundary after sufficient inputs", result.stdout
+            )
             self.assertIn("Stacked JPG candidates found:  2", result.stdout)
             self.assertIn("Accepted stacks:               2", result.stdout)
             self.assertIn(
@@ -227,43 +474,24 @@ class LightroomJpgOnlyGuardTests(unittest.TestCase):
             )
             self.assertEqual(files_under(src), [])
 
-    def test_lightroomimport_rejects_stack_candidate_inside_continuing_bracket(self):
-        """A missing RAW in a long bracket must not look like a stack output.
-
-        This mirrors the P6292502-P6292522 portion of the June 29, 2026
-        regression.  The candidate at P6292519 has 15 valid-looking inputs
-        behind it, while P6292501 is an earlier, genuine stack output separated
-        by five minutes.  A backward-only burst probe is fooled by that older
-        output; the frames after P6292519 prove that the bracket is continuing.
-        """
+    def test_lightroomimport_preserves_backward_overlength_safeguard(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             src = root / "card"
             lightroom = root / "Lightroom"
             stack_input = root / "StackInput"
-            stack_time = datetime(2026, 6, 29, 11, 35, 28)
-            bracket_time = stack_time + timedelta(minutes=5)
+            base_time = datetime(2026, 7, 14, 14, 0, 0)
 
-            # A real six-input in-camera stack immediately before the bracket.
-            for number in range(2495, 2501):
-                mtime = stack_time + timedelta(
-                    milliseconds=(number - 2495) * 100
-                )
-                write_media_file(src / f"P629{number}.JPG", mtime)
-                write_media_file(src / f"P629{number}.ORF", mtime)
+            # Fifteen inferred inputs hit the cap; the three immediately older
+            # consecutive frames remain within the original backward gap rule.
+            for number in range(1, 19):
+                mtime = base_time + timedelta(milliseconds=number * 100)
+                write_media_file(src / f"_716{number:04d}.JPG", mtime)
+                write_media_file(src / f"_716{number:04d}.ORF", mtime)
             write_media_file(
-                src / "P6292501.JPG", stack_time + timedelta(seconds=1)
+                src / "_7160019.JPG",
+                base_time + timedelta(milliseconds=1900),
             )
-
-            # A long focus bracket.  P6292519 deliberately lacks its RAW to
-            # exercise burst safety independently of the all-RAW-backed guard.
-            for number in range(2502, 2523):
-                mtime = bracket_time + timedelta(
-                    milliseconds=(number - 2502) * 100
-                )
-                write_media_file(src / f"P629{number}.JPG", mtime)
-                if number != 2519:
-                    write_media_file(src / f"P629{number}.ORF", mtime)
 
             result = self.run_stackcopy(
                 ["--lightroomimport", str(src), "--debug-stacks"],
@@ -273,55 +501,39 @@ class LightroomJpgOnlyGuardTests(unittest.TestCase):
 
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
             self.assertIn(
-                "Burst Safety Check: TRIGGERED. Burst continues after output "
-                "candidate with 3 frames within 2.0s.",
+                "Burst Safety Check: TRIGGERED. Found 3 extra frames within "
+                "2.0s of start.",
                 result.stdout,
             )
-            self.assertIn("Stacked JPG candidates found:  2", result.stdout)
-            self.assertIn("Accepted stacks:               1", result.stdout)
+            self.assertIn("Accepted stacks:               0", result.stdout)
+            self.assertIn("Burst safety:              1", result.stdout)
             self.assertIn(
-                "Breakdown: 1 stacked outputs, 12 stack inputs, 41 remaining",
+                "Breakdown: 0 stacked outputs, 0 stack inputs, 37 remaining",
                 result.stdout,
             )
-
-            lightroom_files = {p.name for p in files_under(lightroom)}
-            stack_files = {p.name for p in files_under(stack_input)}
-            self.assertIn("P6292501 stacked.JPG", lightroom_files)
-            self.assertIn("P6292519.JPG", lightroom_files)
-            self.assertNotIn("P6292519 stacked.JPG", lightroom_files)
-            self.assertEqual(
-                {
-                    name
-                    for number in range(2495, 2501)
-                    for name in (f"P629{number}.JPG", f"P629{number}.ORF")
-                },
-                stack_files,
-            )
+            imported_names = {path.name for path in files_under(lightroom)}
+            self.assertIn("_7160019.JPG", imported_names)
+            self.assertNotIn("_7160019 stacked.JPG", imported_names)
+            self.assertEqual(files_under(stack_input), [])
             self.assertEqual(files_under(src), [])
 
-    def test_lightroomimport_immediate_consecutive_stacks_are_not_one_burst(self):
-        """Already-claimed frames after an output start the next real stack."""
+    def test_backward_probe_numeric_gap_does_not_trigger_rejection(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             src = root / "card"
             lightroom = root / "Lightroom"
             stack_input = root / "StackInput"
-            base_time = datetime(2026, 6, 29, 12, 0, 0)
+            base_time = datetime(2026, 7, 14, 14, 30, 0)
 
-            # Both complete stacks fit inside the forward guard's two-second
-            # window.  Reverse processing accepts the second stack first and
-            # its claimed inputs must act as a boundary for the first one.
-            for number in (1, 2, 3, 5, 6, 7):
+            # Frames 5-19 fill the input window. Frames 4 and 3 form only a
+            # partial backward probe because frame 2 is absent.
+            for number in (1, *range(3, 20)):
                 mtime = base_time + timedelta(milliseconds=number * 100)
-                write_media_file(src / f"_629{number:04d}.JPG", mtime)
-                write_media_file(src / f"_629{number:04d}.ORF", mtime)
+                write_media_file(src / f"_717{number:04d}.JPG", mtime)
+                write_media_file(src / f"_717{number:04d}.ORF", mtime)
             write_media_file(
-                src / "_6290004.JPG",
-                base_time + timedelta(milliseconds=400),
-            )
-            write_media_file(
-                src / "_6290008.JPG",
-                base_time + timedelta(milliseconds=800),
+                src / "_7170020.JPG",
+                base_time + timedelta(milliseconds=2000),
             )
 
             result = self.run_stackcopy(
@@ -332,15 +544,80 @@ class LightroomJpgOnlyGuardTests(unittest.TestCase):
 
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
             self.assertNotIn("Burst Safety Check: TRIGGERED", result.stdout)
-            self.assertIn("Accepted stacks:               2", result.stdout)
+            self.assertIn("Accepted stacks:               1", result.stdout)
             self.assertIn(
-                "Breakdown: 2 stacked outputs, 12 stack inputs, 0 remaining",
+                "Breakdown: 1 stacked outputs, 30 stack inputs, 6 remaining",
                 result.stdout,
             )
-            self.assertEqual(
-                {"_6290004 stacked.JPG", "_6290008 stacked.JPG"},
-                {p.name for p in files_under(lightroom)},
+            self.assertIn(
+                "_7170020 stacked.JPG",
+                {path.name for path in files_under(lightroom)},
             )
+            self.assertEqual(30, len(files_under(stack_input)))
+            self.assertEqual(files_under(src), [])
+
+    def test_missing_backward_probe_mtime_does_not_trigger_rejection(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src = root / "card"
+            lightroom = root / "Lightroom"
+            stack_input = root / "StackInput"
+            base_time = datetime(2026, 7, 14, 15, 0, 0)
+
+            for number in range(1, 19):
+                mtime = base_time + timedelta(milliseconds=number * 100)
+                write_media_file(src / f"_718{number:04d}.JPG", mtime)
+                write_media_file(src / f"_718{number:04d}.ORF", mtime)
+            write_media_file(
+                src / "_7180019.JPG",
+                base_time + timedelta(milliseconds=1900),
+            )
+
+            original_get_stem_mtime = stackcopy_module.get_stem_mtime
+
+            def get_stem_mtime_with_missing_probe(record, verbose=False):
+                raw_record = record["files"].get("raw")
+                if raw_record and raw_record["basename"] == "_7180002.ORF":
+                    return None
+                return original_get_stem_mtime(record, verbose)
+
+            output = io.StringIO()
+            env = {
+                "STACKCOPY_LIGHTROOM_IMPORT_DIR": str(lightroom),
+                "STACKCOPY_STACK_INPUT_DIR": str(stack_input),
+                "STACKCOPY_ASSUME_YES": "1",
+            }
+            with (
+                mock.patch.dict(os.environ, env),
+                mock.patch.object(
+                    stackcopy_module, "STACK_INPUT_DIR", str(stack_input)
+                ),
+                mock.patch.object(
+                    stackcopy_module,
+                    "get_stem_mtime",
+                    get_stem_mtime_with_missing_probe,
+                ),
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    [str(STACKCOPY), "--lightroomimport", str(src), "--debug-stacks"],
+                ),
+                redirect_stdout(output),
+            ):
+                stackcopy_module.main()
+
+            stdout = output.getvalue()
+            self.assertNotIn("Burst Safety Check: TRIGGERED", stdout)
+            self.assertIn("Accepted stacks:               1", stdout)
+            self.assertIn(
+                "Breakdown: 1 stacked outputs, 30 stack inputs, 6 remaining",
+                stdout,
+            )
+            self.assertIn(
+                "_7180019 stacked.JPG",
+                {path.name for path in files_under(lightroom)},
+            )
+            self.assertEqual(30, len(files_under(stack_input)))
             self.assertEqual(files_under(src), [])
 
     def test_lightroomimport_no_stack_detection_imports_all_as_remaining(self):
@@ -425,9 +702,7 @@ class LightroomJpgOnlyGuardTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
             self.assertIn(f"Running Stackcopy from: {STACKCOPY}", result.stdout)
             self.assertNotIn("JPG-only import detected", result.stdout)
-            self.assertEqual(
-                result.stdout.count("Stack detection skipped in "), 1
-            )
+            self.assertEqual(result.stdout.count("Stack detection skipped in "), 1)
             self.assertIn(
                 "inferred input frames are not all RAW-backed. Enable RAW+JPG for automatic stack sorting.",
                 result.stdout,
@@ -438,9 +713,7 @@ class LightroomJpgOnlyGuardTests(unittest.TestCase):
             )
             self.assertIn("Stacked JPG candidates found:  26", result.stdout)
             self.assertIn("Accepted stacks:               0", result.stdout)
-            self.assertIn(
-                "Input sequences not all RAW-backed skipped:", result.stdout
-            )
+            self.assertIn("Input sequences not all RAW-backed skipped:", result.stdout)
             self.assertIn("Will move 0 stacked output files", result.stdout)
             self.assertIn("Will move 0 stack input files", result.stdout)
             self.assertIn("Will move 46 remaining files", result.stdout)

--- a/tests/test_lightroom_jpg_only_guard.py
+++ b/tests/test_lightroom_jpg_only_guard.py
@@ -49,7 +49,7 @@ class LightroomJpgOnlyGuardTests(unittest.TestCase):
         )
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertEqual(result.stdout.strip(), "Stackcopy 1.5.7")
+        self.assertEqual(result.stdout.strip(), "Stackcopy 1.5.8")
 
     def test_lightroomimport_jpg_only_repro_imports_all_as_remaining(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -224,6 +224,122 @@ class LightroomJpgOnlyGuardTests(unittest.TestCase):
                     "_6170007.ORF",
                 },
                 stack_files,
+            )
+            self.assertEqual(files_under(src), [])
+
+    def test_lightroomimport_rejects_stack_candidate_inside_continuing_bracket(self):
+        """A missing RAW in a long bracket must not look like a stack output.
+
+        This mirrors the P6292502-P6292522 portion of the June 29, 2026
+        regression.  The candidate at P6292519 has 15 valid-looking inputs
+        behind it, while P6292501 is an earlier, genuine stack output separated
+        by five minutes.  A backward-only burst probe is fooled by that older
+        output; the frames after P6292519 prove that the bracket is continuing.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src = root / "card"
+            lightroom = root / "Lightroom"
+            stack_input = root / "StackInput"
+            stack_time = datetime(2026, 6, 29, 11, 35, 28)
+            bracket_time = stack_time + timedelta(minutes=5)
+
+            # A real six-input in-camera stack immediately before the bracket.
+            for number in range(2495, 2501):
+                mtime = stack_time + timedelta(
+                    milliseconds=(number - 2495) * 100
+                )
+                write_media_file(src / f"P629{number}.JPG", mtime)
+                write_media_file(src / f"P629{number}.ORF", mtime)
+            write_media_file(
+                src / "P6292501.JPG", stack_time + timedelta(seconds=1)
+            )
+
+            # A long focus bracket.  P6292519 deliberately lacks its RAW to
+            # exercise burst safety independently of the all-RAW-backed guard.
+            for number in range(2502, 2523):
+                mtime = bracket_time + timedelta(
+                    milliseconds=(number - 2502) * 100
+                )
+                write_media_file(src / f"P629{number}.JPG", mtime)
+                if number != 2519:
+                    write_media_file(src / f"P629{number}.ORF", mtime)
+
+            result = self.run_stackcopy(
+                ["--lightroomimport", str(src), "--debug-stacks"],
+                lightroom,
+                stack_input,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn(
+                "Burst Safety Check: TRIGGERED. Burst continues after output "
+                "candidate with 3 frames within 2.0s.",
+                result.stdout,
+            )
+            self.assertIn("Stacked JPG candidates found:  2", result.stdout)
+            self.assertIn("Accepted stacks:               1", result.stdout)
+            self.assertIn(
+                "Breakdown: 1 stacked outputs, 12 stack inputs, 41 remaining",
+                result.stdout,
+            )
+
+            lightroom_files = {p.name for p in files_under(lightroom)}
+            stack_files = {p.name for p in files_under(stack_input)}
+            self.assertIn("P6292501 stacked.JPG", lightroom_files)
+            self.assertIn("P6292519.JPG", lightroom_files)
+            self.assertNotIn("P6292519 stacked.JPG", lightroom_files)
+            self.assertEqual(
+                {
+                    name
+                    for number in range(2495, 2501)
+                    for name in (f"P629{number}.JPG", f"P629{number}.ORF")
+                },
+                stack_files,
+            )
+            self.assertEqual(files_under(src), [])
+
+    def test_lightroomimport_immediate_consecutive_stacks_are_not_one_burst(self):
+        """Already-claimed frames after an output start the next real stack."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src = root / "card"
+            lightroom = root / "Lightroom"
+            stack_input = root / "StackInput"
+            base_time = datetime(2026, 6, 29, 12, 0, 0)
+
+            # Both complete stacks fit inside the forward guard's two-second
+            # window.  Reverse processing accepts the second stack first and
+            # its claimed inputs must act as a boundary for the first one.
+            for number in (1, 2, 3, 5, 6, 7):
+                mtime = base_time + timedelta(milliseconds=number * 100)
+                write_media_file(src / f"_629{number:04d}.JPG", mtime)
+                write_media_file(src / f"_629{number:04d}.ORF", mtime)
+            write_media_file(
+                src / "_6290004.JPG",
+                base_time + timedelta(milliseconds=400),
+            )
+            write_media_file(
+                src / "_6290008.JPG",
+                base_time + timedelta(milliseconds=800),
+            )
+
+            result = self.run_stackcopy(
+                ["--lightroomimport", str(src), "--debug-stacks"],
+                lightroom,
+                stack_input,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertNotIn("Burst Safety Check: TRIGGERED", result.stdout)
+            self.assertIn("Accepted stacks:               2", result.stdout)
+            self.assertIn(
+                "Breakdown: 2 stacked outputs, 12 stack inputs, 0 remaining",
+                result.stdout,
+            )
+            self.assertEqual(
+                {"_6290004 stacked.JPG", "_6290008 stacked.JPG"},
+                {p.name for p in files_under(lightroom)},
             )
             self.assertEqual(files_under(src), [])
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Lightroom stack detection to reject candidates embedded in continuing focus brackets.
  - Preserved boundaries between consecutive in-camera stacks to prevent accidental merging.

- **Bug Fixes**
  - Fixed false positives involving JPG-only candidates, missing RAW files, and long focus brackets.
  - Improved burst detection when related frames continue after a candidate.

- **Documentation**
  - Updated release notes and version information to 1.5.8 (July 13, 2026).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->